### PR TITLE
Builds images for releases

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -23,15 +23,31 @@ jobs:
         sudo apt install qemu qemu-user-static
         sudo update-binfmts --enable
 
+    - name: Detect if release
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          echo "IS_RELEASE=1" >> $GITHUB_ENV
+        else
+          echo "IS_RELEASE=0" >> $GITHUB_ENV
+        fi
+
     # Build image with docker
-    - name: Build the full image
-      run: ./build-docker.sh -c gl-config-release
+    - name: Build the full images
+      run: |
+        if [[ ${IS_RELEASE} == "1" ]]; then
+          # Do a release build.
+          ./build-docker.sh -c gl-config-release
+        else
+          # faster test build.
+          ./build-docker.sh -c gl-config
+        fi
 
     # Print output directory files
     - name: List output files
       run: ls -lh deploy
 
     - name: Upload built image
+      if: env.IS_RELASE == '1'
       uses: actions/upload-artifact@v3
       with:
         name: rpios-image
@@ -39,6 +55,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload debug artifacts
+      if: env.IS_RELASE == '1'
       uses: actions/upload-artifact@v3
       with:
         name: debug-files

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -47,7 +47,7 @@ jobs:
       run: ls -lh deploy
 
     - name: Upload built image
-      if: env.IS_RELASE == '1'
+      if: env.IS_RELEASE == '1'
       uses: actions/upload-artifact@v3
       with:
         name: rpios-image
@@ -55,7 +55,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload debug artifacts
-      if: env.IS_RELASE == '1'
+      if: env.IS_RELEASE == '1'
       uses: actions/upload-artifact@v3
       with:
         name: debug-files

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,62 @@
+name: build-images
+
+on:
+  push:
+    branches: [ main ]
+    tags: 
+      - '*'
+  pull_request:
+    # all branches for now while we're testing.
+    #branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: install needed packages
+      run: |
+        sudo apt update
+        sudo apt install binfmt-support
+        sudo apt install qemu qemu-user-static
+        sudo update-binfmts --enable
+
+    # Build image with docker
+    - name: Build the full image
+      run: ./build-docker.sh -c gl-config-release
+
+    # Print output directory files
+    - name: List output files
+      run: ls -lh deploy
+
+    - name: Upload built image
+      uses: actions/upload-artifact@v3
+      with:
+        name: rpios-image
+        path: ./deploy/image_*.img.xz
+        if-no-files-found: error
+
+    - name: Upload debug artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: debug-files
+        path: | 
+          ./deploy/*.info
+          ./deploy/build.log
+        if-no-files-found: error
+  
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [build]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: rpios-image
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: '**/*'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/GL-README.md
+++ b/GL-README.md
@@ -6,9 +6,8 @@ and the Monitoring Notification Server (MNS).  The OS images are available in th
 There are several different images available, depending on your needs, from smallest to largest:
 
 - **`sdk`** - A minimal image with just the Python SDK installed.  This is the smallest image, and is suitable for running the SDK on a Raspberry Pi Zero W.  It is also suitable for running the SDK on a Raspberry Pi 3 or 4, if you don't need the GUI.
-- **`mns`** - an image with the [Groundlight Monitoring Notification Server (MNS)](https://github.com/groundlight/monitoring-notification-server) installed for headless use.  "Headless" means as server, without a GUI.  The MNS provides a simple GUI to configure a Groundlight detector, grab images from it, and send notifications when
-appropriate.
-- **`full`** - an image with the Groundlight MNS installed, and a GUI enabled.  This is appropriate for a Raspberry Pi which will have a screen attached to it.
+- **`mns`** - an image with the [Groundlight Monitoring Notification Server (MNS)](https://github.com/groundlight/monitoring-notification-server) installed for headless use.  "Headless" means it runs the server, which serves HTML pages, but has no browser or GUI to use it from.  You need to connect from another machine to use MNS.  The MNS provides a simple way to configure cameras, Groundlight detectors, and send notifications conditions are met.
+- **`full`** - an image with the Groundlight MNS installed, and a desktop GUI with a browser.  This is appropriate for a Raspberry Pi which will have a screen attached to it.
 - **`edge`** - Not available yet.  The Edge Endpoint server is still too resource hungry to run on a Raspberry Pi.  Please [leave a comment](https://github.com/groundlight/groundlight-pi-gen/issues/5) if you'd like to use this.
 
 

--- a/GL-README.md
+++ b/GL-README.md
@@ -3,7 +3,7 @@
 This repo builds OS images for Groundlight tools and applications, including the bare python SDK, 
 and the Monitoring Notification Server (MNS).  The OS images are available in the [releases](https://github.com/groundlight/groundlight-pi-gen/releases) and can be installed with [Raspberry Pi imager](https://www.raspberrypi.com/software/).
 
-There are several different images available, depending on your needs:
+There are several different images available, depending on your needs, from smallest to largest:
 
 - **`sdk`** - A minimal image with just the Python SDK installed.  This is the smallest image, and is suitable for running the SDK on a Raspberry Pi Zero W.  It is also suitable for running the SDK on a Raspberry Pi 3 or 4, if you don't need the GUI.
 - **`mns`** - an image with the [Groundlight Monitoring Notification Server (MNS)](https://github.com/groundlight/monitoring-notification-server) installed for headless use.  "Headless" means as server, without a GUI.  The MNS provides a simple GUI to configure a Groundlight detector, grab images from it, and send notifications when
@@ -14,7 +14,7 @@ appropriate.
 
 ## Source Code
 
-This build system is based on [pi-gen](https://github.com/RPi-Distro/pi-gen).  Refer to its [original README](/README.md) for how everything works.  The (`glmns-config`)[glmns-config] file is the key source of control.  (What is called "config" in the original.)
+This build system is based on [pi-gen](https://github.com/RPi-Distro/pi-gen).  Refer to its [original README](/README.md) for how everything works.  The (`gl-config`)[gl-config] file is the key source of control.  (What is called "config" in the original.)
 
 Note that we're tracking the `arm64` branch, not main.  (If we build off the main branch, we hit [an issue with missing `arm/v8` docker images](https://github.com/groundlight/monitoring-notification-server/issues/39) and likely others, because we make these funky machines with a 64-bit kernel, but 32-bit applications.)
 
@@ -22,7 +22,7 @@ Note that we're tracking the `arm64` branch, not main.  (If we build off the mai
 ## Building Images
 
 You should really build this on an ARM system (e.g. an m7g instance in ec2).  
-You _can_ build this on an x86 instance, but it will take ~3x longer, and it's not fast to start with.
+You _can_ build this on an x86 instance, but it will take significantly longer, and it's not fast to start with.
 
 ### Building directly
 
@@ -56,7 +56,7 @@ To start over try
 
 After ~10 minutes, and then look in the `deploy/` for a file with a name like
 `image_2023-12-06-GroundlightMNS-sdk-qemu.img.xz` which will be ~1GB for now.
-(See the `COMPRESSION_LEVEL` setting in (`glmns-config`)[glmns-config] to trade speed vs size.)
+(See the `COMPRESSION_LEVEL` setting in (`gl-config`)[gl-config] to trade speed vs size.)
 
 Copy this to your laptop, and then you can burn it to an SD card using the [Raspberry Pi Image](https://github.com/raspberrypi/rpi-imager).
 

--- a/GL-README.md
+++ b/GL-README.md
@@ -1,14 +1,22 @@
-# Groundlight' Monitoring Notification Server (MNS) as a Raspberry Pi Appliance
+# Groundlight Pi-Gen: OS images for Raspberry PI with Groundlight Tools
 
-This repo builds the OS image for a Groundlight MNS appliance running on Raspberry Pi hardware.
+This repo builds OS images for Groundlight tools and applications, including the bare python SDK, 
+and the Monitoring Notification Server (MNS).  The OS images are available in the [releases](https://github.com/groundlight/groundlight-pi-gen/releases) and can be installed with [Raspberry Pi imager](https://www.raspberrypi.com/software/).
 
-Use this repo to build the `.img` file which gets burned to an SD card.  When that SD card is booted on the Raspberry Pi, 
-it runs the [Groundlight Monitoring Notification Server](https://github.com/groundlight/monitoring-notification-server).
-The MNS provides a simple GUI to configure a Groundlight detector, grab images from it, and send notifications when
+There are several different images available, depending on your needs:
+
+- **`sdk`** - A minimal image with just the Python SDK installed.  This is the smallest image, and is suitable for running the SDK on a Raspberry Pi Zero W.  It is also suitable for running the SDK on a Raspberry Pi 3 or 4, if you don't need the GUI.
+- **`mns`** - an image with the [Groundlight Monitoring Notification Server (MNS)](https://github.com/groundlight/monitoring-notification-server) installed for headless use.  "Headless" means as server, without a GUI.  The MNS provides a simple GUI to configure a Groundlight detector, grab images from it, and send notifications when
 appropriate.
+- **`full`** - an image with the Groundlight MNS installed, and a GUI enabled.  This is appropriate for a Raspberry Pi which will have a screen attached to it.
+- **`edge`** - Not available yet.  The Edge Endpoint server is still too resource hungry to run on a Raspberry Pi.  Please [leave a comment](https://github.com/groundlight/groundlight-pi-gen/issues/5) if you'd like to use this.
+
+
+## Source Code
 
 This build system is based on [pi-gen](https://github.com/RPi-Distro/pi-gen).  Refer to its [original README](/README.md) for how everything works.  The (`glmns-config`)[glmns-config] file is the key source of control.  (What is called "config" in the original.)
-Also note that we're tracking the `arm64` branch, not main.  (If we build off the main branch, we hit [an issue with missing `arm/v8` docker images](https://github.com/groundlight/monitoring-notification-server/issues/39) and likely others, because we make these funky machines with a 64-bit kernel, but 32-bit applications.)
+
+Note that we're tracking the `arm64` branch, not main.  (If we build off the main branch, we hit [an issue with missing `arm/v8` docker images](https://github.com/groundlight/monitoring-notification-server/issues/39) and likely others, because we make these funky machines with a 64-bit kernel, but 32-bit applications.)
 
 
 ## Building Images

--- a/dobuild.sh
+++ b/dobuild.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # local build - seems like maybe it's leaking system resources sometimes?
-# time sudo $@ ./build.sh -c glmns-config
+# time sudo $@ ./build.sh -c gl-config
 
 # docker build - slower but more reliable.
-time PRESERVE_CONTAINER=1 $@ ./build-docker.sh -c glmns-config
+time PRESERVE_CONTAINER=1 $@ ./build-docker.sh -c gl-config

--- a/gl-config
+++ b/gl-config
@@ -20,7 +20,7 @@ STAGE_LIST="stage0 stage1 stage2 stage-gl1"
 
 #
 # Options used for development.
-# (These get overridden by gl-config-prod)
+# (These get overridden by gl-config-release)
 #
 
 # Makes a qemu-compatible image - for easier testing.

--- a/gl-config
+++ b/gl-config
@@ -1,7 +1,7 @@
 # The config file defining the Groundlight MNS image.
 IMG_NAME='GroundlightMNS'
 TARGET_HOSTNAME=GroundlightMNS
-FIRST_USER_NAME=glmns
+FIRST_USER_NAME=groundlight
 
 #
 # core functionality
@@ -20,7 +20,7 @@ STAGE_LIST="stage0 stage1 stage2 stage-gl1"
 
 #
 # Options used for development.
-# (These get overridden by glmns-config-prod)
+# (These get overridden by gl-config-prod)
 #
 
 # Makes a qemu-compatible image - for easier testing.

--- a/gl-config-prod
+++ b/gl-config-prod
@@ -1,4 +1,4 @@
-source glmns-config
+source gl-config
 
 # Higher compression takes longer, so it's turned down during dev.
 # We should turn it back up when we're ready to publish.

--- a/gl-config-release
+++ b/gl-config-release
@@ -1,5 +1,8 @@
 source gl-config
 
+# Turn off QEMU for release builds
+USE_QEMU=0
+
 # Higher compression takes longer, so it's turned down during dev.
 # We should turn it back up when we're ready to publish.
 # For reference, with a 3.3GB base .img file 


### PR DESCRIPTION
Adding a github action which builds OS images, and saves them as release artifacts as appropriate.

Also renamed things in the repo to be less MNS-specific, because this repo will build & release various flavors with and without MNS.