### PR TITLE
Fix small release name bug

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Note: Avoid usage of arrays as MacOS users have an older version of bash (v3.x) which does not supports arrays
+# Note: Avoid usage of arrays as MacOS users have an older version of bash (v3.x) which does not support arrays
 set -eu
 
 DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"

--- a/dobuild.sh
+++ b/dobuild.sh
@@ -43,7 +43,7 @@ if [ "$IS_RELEASE" = "1" ]; then
             echo "Failed to parse filename $filename - got $variant"
             exit 1
         fi
-        new_file="GroundlightPi-$TAG_NAME-$variant.img.xz"
+        new_file="GroundlightPi-$TAG_NAME-$variant"
 
         # Rename the file
         echo "Renaming $file to $new_file"


### PR DESCRIPTION
During deployment we were adding `img.xz` twice. This should fix it. 