### PR TITLE
Emulating the Pi with QEMU

### DIFF
--- a/GL-README.md
+++ b/GL-README.md
@@ -58,9 +58,47 @@ After ~10 minutes, and then look in the `deploy/` for a file with a name like
 
 Copy this to your laptop, and then you can burn it to an SD card using the [Raspberry Pi Image](https://github.com/raspberrypi/rpi-imager).
 
-TODO: figure out how to use them inside `qemu`.
 TODO: set up some tests inside `qemu` that things are working.
 TODO: write those tests into CI/CD actions.
+
+
+## Running the Raspberry Pi Image with QEMU 
+To emulate the Raspberry Pi image with QEMU, we will first need to install the Linux kernel for QEMU on the 
+host machine and install other necessary packages required for QEMU to work. To do this, run 
+
+```shell 
+chmod +x setup-qemu-kernel.sh 
+./setup-qemu-kernel.sh 
+```
+
+This needs to be done only once. It will download a linux kernel of 36MB. 
+
+To run the emulator, go ahead and run 
+
+```shell 
+chmod +x rpistart.sh 
+./rpistart.sh -i <absolute-path-to-image>
+```
+
+The image path must be absolute and it needs to be decompressed. You can decompress the image by runnning 
+
+```shell
+xz -d <path-to-compressed-image> 
+```
+
+This will start the emulator. You can SSH into it by running 
+
+```shell
+ssh -l pi localhost -p 2222
+```
+
+By default, the username and password are `pi` and `raspberry` respectively. You can overrride these by setting 
+the following environment variables before running the `rpistart.sh` script. 
+
+```shell
+export USERNAME=<username>
+export PASSWORD=<password>
+```
 
 
 ## What's up with this file?

--- a/GL-README.md
+++ b/GL-README.md
@@ -84,26 +84,23 @@ To emulate the Raspberry Pi image with QEMU, we will first need to install the L
 host machine and install other necessary packages required for QEMU to work. To do this, run 
 
 ```shell 
-chmod +x setup-qemu-kernel.sh 
 ./setup-qemu-kernel.sh 
 ```
 
-This needs to be done only once. It will download a linux kernel of 36MB. 
-
-To run the emulator, go ahead and run 
-
-```shell 
-chmod +x rpistart.sh 
-./rpistart.sh -i <absolute-path-to-image>
-```
-
-The image path must be absolute and it needs to be decompressed. You can decompress the image by runnning 
+This needs to be done only once. It will download a linux kernel(v6.6.8) of 40MB. 
+If you haven't decompressed the image you wan to use, you can do so by running
 
 ```shell
 xz -d <path-to-compressed-image> 
 ```
 
-This will start the emulator. You can SSH into it by running 
+To run the emulator, go ahead and run 
+
+```shell 
+./rpistart.sh -i <absolute-path-to-image>
+```
+
+You can SSH into it by running 
 
 ```shell
 ssh -l pi localhost -p 2222

--- a/rpistart.sh
+++ b/rpistart.sh
@@ -131,9 +131,6 @@ cd $ROOT_DIR
 sudo umount /mnt/rpi 
 
 # Run the QEMU emulator
-# We need to resize the image to 4GB first (just for the SDK image--should be configurable later)
-# since the virtualizer does not accept raw images whose sizes are not powers of 2. 
-sudo qemu-img resize "$IMAGE_FILE" 4G
 
 # - kernel: This is the path to the QEMU kernel downloaded in step 2
 # - append: Providing the boot arguments directly to the kernel, telling it where to find the 

--- a/rpistart.sh
+++ b/rpistart.sh
@@ -1,0 +1,131 @@
+#!/bin/bash 
+
+
+set -e 
+
+ARCH=arm64
+ROOT_DIR=/home/ubuntu
+NUM_CORES=${NUM_CORES:-$(nproc)}
+IMAGE_FILE=""
+
+# First step: Install the required packages. These include cross-compilers for arm64
+# and required packages for QEMU itself. 
+# NOTE: We probably don't need to install `qemu-system-gui`
+sudo apt install \
+        gcc-aarch64-linux-gnu \
+        g++-aarch64-linux-gnu \
+        qemu \
+        qemubuilder \
+        qemu-system-gui \
+        qemu-system-arm \
+        qemu-utils \
+        qemu-system-data \
+        qemu-system \
+        flex \
+        bison \
+        libssl-dev 
+
+# Second step: Build the Linux kernel for qemu arm64 
+# The kernel can be downloaded from https://www.kernel.org/
+# tar xvJf means: -x: extract, -v: verbose, -J: use the xz compression, -f: specify archive name
+wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.34.tar.xz
+tar xvJf linux-6.1.34.tar.xz 
+cd linux-6.1.34
+
+# Create a .config file: This requires having flex and bison packages installed: 
+# Flex (Fast Lexial Analyzer Generator) is used for tokenizing input (breaking it into a series of tokens)
+# and Bison takes these tokens and analyzes their structure to understand the higher-level syntax. 
+
+ARCH=${ARCH} CROSS_COMPILE=/bin/aarch64-linux-gnu- make defconfig
+
+# Use the kvm_guest (kernel virtual machine) config as the base defconfig, which is suitable for qemu 
+ARCH=${ARCH} CROSS_COMPILE=/bin/aarch64-linux-gnu- make kvm_guest.config
+
+# Build the kernel (parallelizable if nproc > 1)
+ARCH=arm64 CROSS_COMPILE=/bin/aarch64-linux-gnu- make -j${NUM_CORES}
+
+cp arch/${ARCH}/boot/Image ${ROOT_DIR}
+
+
+# Third step: Mount the image for enabling SSH and configuring username and password 
+
+
+while getopts "i:" flag; do 
+do 
+    case "${flag}" in 
+        i)
+            IMAGE_FILE="${OPTARG}"
+            ;;
+        *)
+            ;;
+    esac
+done 
+
+function assert_numeric() {
+    if ! [[ $1 =~ ^[0-9]+$ ]] || ! [[ $1 =~ ^[0-9]+$ ]]; then
+        echo "Error: Non-numeric value detected."
+        exit 1
+    fi
+}
+
+# Check that the image exists 
+if [ ! -f "${IMAGE_FILE}" ]; then 
+    echo "Invalid Raspberry Pi OS image: '${IMAGE_FILE}'"
+    exit 1
+fi 
+
+
+# Extracting sector size
+SECTOR_SIZE=$(fdisk -l $IMAGE_FILE | grep "Sector size" | awk '{print $4}')
+
+# Extracting the start of the first partition
+START_SECTOR=$(fdisk -l $IMAGE_FILE | grep -E "\.img1" | awk '{print $2}')
+
+assert_numeric $SECTOR_SIZE
+assert_numeric $START_SECTOR
+
+# Calculating the offset
+OFFSET=$(echo "$SECTOR_SIZE * $START_SECTOR" | bc)
+
+
+echo "Sector Size: $SECTOR_SIZE"
+echo "Start Sector: $START_SECTOR"
+echo "Offset: $OFFSET"
+        
+
+
+sudo qemu-img resize \
+        /home/ubuntu/groundlight-pi-gen/deploy/image_2023-12-14-GroundlightPi-sdk-qemu.img 4G
+
+# sudo qemu-system-arm \
+#     -M raspi2b \ 
+#     -m 1G \
+#     -drive file=/home/ubuntu/groundlight-pi-gen/deploy/image_2023-12-14-GroundlightPi-sdk-qemu.img,format=raw \
+#     -net nic -net user \
+#     -display none \
+#     -serial stdio
+
+qemu-system-aarch64 \
+        -machine virt \
+        -cpu cortex-a72 \
+        -smp 6 \
+        -m 4G \
+        -kernel Image \
+        -append "root=/dev/vda2 rootfstype=ext4 rw panic=0 console=ttyAMA0" \
+        -drive format=raw,file=/home/ubuntu/groundlight-pi-gen/deploy/image_2023-12-14-GroundlightPi-sdk-qemu.img,if=none,id=hd0,cache=writeback \
+        -device virtio-blk,drive=hd0,bootindex=0 \
+        -netdev user,id=mynet,hostfwd=tcp::2222-:22 \
+        -device virtio-net-pci,netdev=mynet \
+        -monitor telnet:127.0.0.1:5555,server,nowait \
+        -nographic 
+
+
+
+# Remember to add a step to add bison and flex 
+# sudo apt-get install flex bison libssl-dev 
+
+# IP address is 10.0.2.15 
+
+# [FAILED] Failed to start rpi-eeprom…k for Raspberry Pi EEPROM updates.
+# See 'systemctl status rpi-eeprom-update.service' for details.
+# [  OK  ] Started avahi-daemon.service - Avahi mDNS/DNS-SD Stack.

--- a/rpistart.sh
+++ b/rpistart.sh
@@ -57,6 +57,7 @@ if [ ! -f "$IMAGE_FILE" ]; then
     exit 1
 elif [[ "$IMAGE_FILE" != /* ]]; then 
     echo "The image path is not absolute: '$IMAGE_FILE'"
+    exit 1
 elif [[ "$IMAGE_FILE" != *qemu.img ]]; then
     echo "The image does not have the expected 'qemu.img' suffix: '$IMAGE_FILE'"
     echo "You probably forgot to decompress the image by running 'xz -d <*.img.xz>'"
@@ -125,6 +126,9 @@ if [ -d "/mnt/rpi" ]; then
     # https://www.openssl.org/docs/man1.0.2/man1/passwd.html#:~:text=The%20passwd%20command%20computes%20the,or%20from%20the%20terminal%20otherwise.
     HASHED_PASSWORD=$(openssl passwd -6 "${PASSWORD}")
     echo "${USERNAME}:${HASHED_PASSWORD}" | sudo tee userconf.txt > /dev/null
+else
+    echo "Image not mounted to /mnt/rpi"
+    exit 1
 fi
 
 cd $ROOT_DIR

--- a/rpistart.sh
+++ b/rpistart.sh
@@ -58,7 +58,7 @@ ARCH=${ARCH} CROSS_COMPILE=/bin/aarch64-linux-gnu- make defconfig
 ARCH=${ARCH} CROSS_COMPILE=/bin/aarch64-linux-gnu- make kvm_guest.config
 
 # Build the kernel (parallelizable if nproc > 1)
-ARCH=arm64 CROSS_COMPILE=/bin/aarch64-linux-gnu- make -j${NUM_CORES}
+ARCH=${ARCH} CROSS_COMPILE=/bin/aarch64-linux-gnu- make -j${NUM_CORES}
 
 cp arch/${ARCH}/boot/Image ${ROOT_DIR}
 
@@ -92,7 +92,7 @@ done
 
 function assert_numeric() {
     if ! [[ $1 =~ ^[0-9]+$ ]] || ! [[ $1 =~ ^[0-9]+$ ]]; then
-        echo "Error: Non-numeric value detected."
+        echo "Error: Non-numeric value detected: $1"
         exit 1
     fi
 }
@@ -173,7 +173,7 @@ sudo qemu-system-aarch64 \
         -m 4G \
         -kernel Image \
         -append "root=/dev/vda2 rootfstype=ext4 rw panic=0 console=ttyAMA0" \
-        -drive format=raw,file=/home/ubuntu/groundlight-pi-gen/deploy/image_2023-12-14-GroundlightPi-sdk-qemu.img,if=none,id=hd0,cache=writeback \
+        -drive format=raw,file=$IMAGE_FILE,if=none,id=hd0,cache=writeback \
         -device virtio-blk,drive=hd0,bootindex=0 \
         -netdev user,id=mynet,hostfwd=tcp::2222-:22 \
         -device virtio-net-pci,netdev=mynet \

--- a/setup-qemu-kernel.sh
+++ b/setup-qemu-kernel.sh
@@ -1,28 +1,26 @@
 #!/bin/bash 
 
 
-set -e 
+set -ex 
 
 
 cd "$(dirname "$0")"
 
 
 ARCH=arm64
-ROOT_DIR=/home/ubuntu
+ROOT_DIR=$HOME 
 NUM_CORES=${NUM_CORES:-$(nproc)}
 IMAGE_FILE=""
 KERNEL_VERSION="linux-6.1.34"
 
 
-# First step: Install the required packages. These include cross-compilers for arm64
+# Install the required packages. These include cross-compilers for arm64
 # and required packages for QEMU itself. 
-# NOTE: We probably don't need to install `qemu-system-gui`
 sudo apt install -y \
         gcc-aarch64-linux-gnu \
         g++-aarch64-linux-gnu \
         qemu \
         qemubuilder \
-        qemu-system-gui \
         qemu-system-arm \
         qemu-utils \
         qemu-system-data \
@@ -31,7 +29,7 @@ sudo apt install -y \
         bison \
         libssl-dev 
 
-# Second step: Build the Linux kernel for qemu arm64 
+# Build the Linux kernel for qemu arm64 
 # The kernel can be downloaded from https://www.kernel.org/
 # tar xvJf means: -x: extract, -v: verbose, -J: use the xz compression, -f: specify archive name
 if [ -d "$KERNEL_VERSION" ]; then

--- a/setup-qemu-kernel.sh
+++ b/setup-qemu-kernel.sh
@@ -1,0 +1,63 @@
+#!/bin/bash 
+
+
+set -e 
+
+
+cd "$(dirname "$0")"
+
+
+ARCH=arm64
+ROOT_DIR=/home/ubuntu
+NUM_CORES=${NUM_CORES:-$(nproc)}
+IMAGE_FILE=""
+KERNEL_VERSION="linux-6.1.34"
+
+
+# First step: Install the required packages. These include cross-compilers for arm64
+# and required packages for QEMU itself. 
+# NOTE: We probably don't need to install `qemu-system-gui`
+sudo apt install -y \
+        gcc-aarch64-linux-gnu \
+        g++-aarch64-linux-gnu \
+        qemu \
+        qemubuilder \
+        qemu-system-gui \
+        qemu-system-arm \
+        qemu-utils \
+        qemu-system-data \
+        qemu-system \
+        flex \
+        bison \
+        libssl-dev 
+
+# Second step: Build the Linux kernel for qemu arm64 
+# The kernel can be downloaded from https://www.kernel.org/
+# tar xvJf means: -x: extract, -v: verbose, -J: use the xz compression, -f: specify archive name
+if [ -d "$KERNEL_VERSION" ]; then
+    echo "Directory $KERNEL_VERSION already exists, skipping download and extraction."
+else
+    # Downloading the kernel source
+    echo "Downloading Linux kernel version $KERNEL_VERSION..."
+    wget "https://cdn.kernel.org/pub/linux/kernel/v6.x/${KERNEL_VERSION}.tar.xz"
+
+    # Extracting the kernel source
+    echo "Extracting ${KERNEL_VERSION}.tar.xz..."
+    tar xvJf "${KERNEL_VERSION}.tar.xz"
+fi
+
+cd "$KERNEL_VERSION"
+
+# Create a .config file: This requires having flex and bison packages installed: 
+# Flex (Fast Lexial Analyzer Generator) is used for tokenizing input (breaking it into a series of tokens)
+# and Bison takes these tokens and analyzes their structure to understand the higher-level syntax. 
+
+ARCH=${ARCH} CROSS_COMPILE=/bin/aarch64-linux-gnu- make defconfig
+
+# Use the kvm_guest (kernel virtual machine) config as the base defconfig, which is suitable for qemu 
+ARCH=${ARCH} CROSS_COMPILE=/bin/aarch64-linux-gnu- make kvm_guest.config
+
+# Build the kernel (parallelizable if nproc > 1)
+ARCH=${ARCH} CROSS_COMPILE=/bin/aarch64-linux-gnu- make -j${NUM_CORES}
+
+cp arch/${ARCH}/boot/Image ${ROOT_DIR}

--- a/setup-qemu-kernel.sh
+++ b/setup-qemu-kernel.sh
@@ -11,7 +11,10 @@ ARCH=arm64
 ROOT_DIR=$HOME 
 NUM_CORES=${NUM_CORES:-$(nproc)}
 IMAGE_FILE=""
-KERNEL_VERSION="linux-6.1.34"
+
+# The most recent linux kernel version at the time of this writing. 
+# Might need to be updated in the future. 
+KERNEL_VERSION="linux-6.6.8"
 
 
 # Install the required packages. These include cross-compilers for arm64


### PR DESCRIPTION
To run this script, you will need to provide the path(absolute) to the image that you want to use. For instance, 

```shell
> ./rpistart.sh -i /home/ubuntu/groundlight-pi-gen/deploy/image_2023-12-14-GroundlightPi-sdk-qemu.img
```
This [tutorial](https://gist.github.com/cGandom/23764ad5517c8ec1d7cd904b923ad863) was particularly helpful.
