### PR TITLE
configure github actions to run on a larger runner

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -11,7 +11,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04-8core
+    runs-on: 
+      labels: ubuntu-22.04-8core
 
     steps:
     - uses: actions/checkout@v4
@@ -60,7 +61,8 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build]
-    runs-on: ubuntu-22.04-8core
+    runs-on: 
+      labels: ubuntu-22.04-8core
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-8core
 
     steps:
     - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-8core
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
I created a larger runner with 8cores, 32 GB of RAM and 300GB of SSD. This change allows us to use this runner type as opposed to the default. 