### PR TITLE
Add python3-dev to enable new version of framegrab

### DIFF
--- a/stage-gl1/00-install-packages/00-packages
+++ b/stage-gl1/00-install-packages/00-packages
@@ -1,7 +1,7 @@
 # Absolute basics
 python3 python-is-python3
 
-# we don't install things like python3-pip or many libraries here, because pip and apt don't 
+# We don't install things like python3-pip or many libraries here, because pip and apt don't 
 # get along, so we'll set up a venv later.
 
 # We'll set up a venv to get around this.
@@ -9,6 +9,10 @@ python3-venv
 
 # We do install OS's opencv to make sure all the .so files are available.
 python3-opencv
+
+# We need to make sure to install this before framegrab -- required to install the netifaces 
+# package. 
+python3-dev
 
 # Some nice-to-have utilities
 iotop nethogs net-tools telnet

--- a/stage-gl1/00-install-packages/00-packages
+++ b/stage-gl1/00-install-packages/00-packages
@@ -11,7 +11,7 @@ python3-venv
 python3-opencv
 
 # We need to make sure to install this before framegrab -- required to install the netifaces 
-# package. 
+# package.   In general, python packages which build C code need this to install even through pip
 python3-dev
 
 # Some nice-to-have utilities


### PR DESCRIPTION
## Description
Adding `python3-dev` as a dependency in the Groundlight packages portion of the setup scripts. This is required to enable the new version of framegrab.

## Testing

- [x] Build new raspberry pi image from scratch using `dobuild.sh` script with `CLEAN=1` option
- [x] Boot image onto Raspberry Pi 4
- [x] Run basic groundlight application (submitting queries) from Raspberry Pi 4 with new image and USB camera