### PR TITLE
Add support for Raspberry Pi CSI2 cameras

### DIFF
--- a/stage-gl1/01-install-python-libraries/00-run-chroot.sh
+++ b/stage-gl1/01-install-python-libraries/00-run-chroot.sh
@@ -1,13 +1,19 @@
 #!/bin/bash -e
 
-# set up a groundlight virtual environment for python
-python3 -m venv /opt/groundlight/gl-py
+# Set up a groundlight virtual environment for python. --system-site-packages is
+# required for picamera2.
+python3 -m venv /opt/groundlight/gl-py --system-site-packages
 source /opt/groundlight/gl-py/bin/activate
 
 # Now install the groundlight python libraries
 pip install groundlight
 # framegrab will install opencv-python, numpy, and pillow
 pip install framegrab
+
+# Install picamera2, required for use of Raspberry Pi CSI2 cameras. Note that there is
+# an option to install through pip, but that is not the reccommended installation
+# method. --no-install-recommends prevents installation of GUI dependencies.
+sudo apt install -y python3-picamera2 --no-install-recommends
 
 # add a .bashrc entry to activate the groundlight virtual environment
 echo "source /opt/groundlight/gl-py/bin/activate" >> /home/${FIRST_USER_NAME}/.bashrc


### PR DESCRIPTION
## Description
This PR makes some modifications to support Raspberry Pi CSI2 cameras without any additional installations. The picamera2 library is installed using the recommended installation method, and the venv is updated to support that installation.

## Testing

- [x] Built successfully using `CLEAN=1 ./dobuild.sh`
- [x] Loaded onto Raspberry Pi 4 and ran sample script with framegrab and Raspberry Pi CSI2 camera with no additional installs
- [x] Loaded onto Raspberry Pi Zero 2 and ran sample script with framegrab and Raspberry Pi CSI2 camera with no additional installs